### PR TITLE
Modify common classes to be compatible with TAssist

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -13,8 +13,8 @@ import seedu.address.commons.core.Version;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.commons.util.ConfigUtil;
 import seedu.address.commons.util.StringUtil;
-import seedu.address.logic.AB3Logic;
-import seedu.address.logic.AB3LogicManager;
+import seedu.address.logic.Logic;
+import seedu.address.logic.LogicManager;
 import seedu.address.model.AB3Model;
 import seedu.address.model.AB3ModelManager;
 import seedu.address.model.AddressBook;
@@ -41,7 +41,7 @@ public class MainApp extends Application {
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 
     protected Ui ui;
-    protected AB3Logic logic;
+    protected Logic logic;
     protected Storage storage;
     protected AB3Model model;
     protected Config config;
@@ -63,7 +63,7 @@ public class MainApp extends Application {
 
         model = initModelManager(storage, userPrefs);
 
-        logic = new AB3LogicManager(model, storage);
+        logic = new LogicManager(model, storage);
 
         ui = new UiManager(logic);
     }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -15,13 +15,14 @@ import seedu.address.model.student.Student;
 import seedu.address.model.tamodule.TaModule;
 
 /**
- * API of the Logic component
+ * API of the Logic component.
  */
 public interface Logic {
     /**
      * Executes the command and returns the result.
+     *
      * @param commandText The command as entered by the user.
-     * @return the result of the command execution.
+     * @return The result of the command execution.
      * @throws CommandException If an error occurs during command execution.
      * @throws ParseException If an error occurs during parsing.
      */
@@ -34,16 +35,16 @@ public interface Logic {
      */
     ReadOnlyTAssist getTAssist();
 
-    /** Returns an unmodifiable view of the filtered list of students */
+    /** Returns an unmodifiable view of the filtered list of students. */
     ObservableList<Student> getFilteredStudentList();
 
-    /** Returns an unmodifiable view of the filtered list of modules */
+    /** Returns an unmodifiable view of the filtered list of modules. */
     ObservableList<TaModule> getFilteredModuleList();
 
-    /** Returns an unmodifiable view of the filtered list of class groups */
+    /** Returns an unmodifiable view of the filtered list of class groups. */
     ObservableList<ClassGroup> getFilteredClassGroupList();
 
-    /** to be removed */
+    /** TODO: to be removed */
     ObservableList<Person> getFilteredPersonList();
 
     /**

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -1,0 +1,63 @@
+package seedu.address.logic;
+
+import java.nio.file.Path;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyTAssist;
+import seedu.address.model.classgroup.ClassGroup;
+import seedu.address.model.person.Person;
+import seedu.address.model.student.Student;
+import seedu.address.model.tamodule.TaModule;
+
+/**
+ * API of the Logic component
+ */
+public interface Logic {
+    /**
+     * Executes the command and returns the result.
+     * @param commandText The command as entered by the user.
+     * @return the result of the command execution.
+     * @throws CommandException If an error occurs during command execution.
+     * @throws ParseException If an error occurs during parsing.
+     */
+    CommandResult execute(String commandText) throws CommandException, ParseException;
+
+    /**
+     * Returns the TAssist.
+     *
+     * @see Model#getTAssist()
+     */
+    ReadOnlyTAssist getTAssist();
+
+    /** Returns an unmodifiable view of the filtered list of students */
+    ObservableList<Student> getFilteredStudentList();
+
+    /** Returns an unmodifiable view of the filtered list of modules */
+    ObservableList<TaModule> getFilteredModuleList();
+
+    /** Returns an unmodifiable view of the filtered list of class groups */
+    ObservableList<ClassGroup> getFilteredClassGroupList();
+
+    /** to be removed */
+    ObservableList<Person> getFilteredPersonList();
+
+    /**
+     * Returns the user prefs' address book file path.
+     */
+    Path getTAssistFilePath();
+
+    /**
+     * Returns the user prefs' GUI settings.
+     */
+    GuiSettings getGuiSettings();
+
+    /**
+     * Set the user prefs' GUI settings.
+     */
+    void setGuiSettings(GuiSettings guiSettings);
+}

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -82,7 +82,7 @@ public class LogicManager implements Logic {
         return model.getFilteredClassGroupList();
     }
 
-    /** to be removed*/
+    /** TODO: to be removed*/
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return ab3model.getFilteredPersonList();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -1,0 +1,105 @@
+package seedu.address.logic;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.AddressBookParser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.AB3Model;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.ReadOnlyTAssist;
+import seedu.address.model.classgroup.ClassGroup;
+import seedu.address.model.person.Person;
+import seedu.address.model.student.Student;
+import seedu.address.model.tamodule.TaModule;
+import seedu.address.storage.Storage;
+
+/**
+ * The main LogicManager of the app.
+ */
+public class LogicManager implements Logic {
+    public static final String FILE_OPS_ERROR_MESSAGE = "Could not save data to file: ";
+    private final Logger logger = LogsCenter.getLogger(LogicManager.class);
+
+    private final Model model;
+    private final AB3Model ab3model;
+    private final Storage storage;
+    private final AddressBookParser addressBookParser;
+
+    /**
+     * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
+     */
+    public LogicManager(AB3Model model, Storage storage) {
+        this.ab3model = model;
+        // to be updated
+        this.model = new ModelManager();
+        this.storage = storage;
+        addressBookParser = new AddressBookParser();
+    }
+
+    @Override
+    public CommandResult execute(String commandText) throws CommandException, ParseException {
+        logger.info("----------------[USER COMMAND][" + commandText + "]");
+
+        CommandResult commandResult;
+        Command command = addressBookParser.parseCommand(commandText);
+        commandResult = command.execute(ab3model);
+
+        try {
+            storage.saveAddressBook(ab3model.getAddressBook());
+        } catch (IOException ioe) {
+            throw new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe);
+        }
+
+        return commandResult;
+    }
+
+    @Override
+    public ReadOnlyTAssist getTAssist() {
+        return model.getTAssist();
+    }
+
+    @Override
+    public ObservableList<Student> getFilteredStudentList() {
+        return model.getFilteredStudentList();
+    }
+
+    @Override
+    public ObservableList<TaModule> getFilteredModuleList() {
+        return model.getFilteredModuleList();
+    }
+
+    @Override
+    public ObservableList<ClassGroup> getFilteredClassGroupList() {
+        return model.getFilteredClassGroupList();
+    }
+
+    /** to be removed*/
+    @Override
+    public ObservableList<Person> getFilteredPersonList() {
+        return ab3model.getFilteredPersonList();
+    }
+
+    @Override
+    public Path getTAssistFilePath() {
+        return model.getTAssistFilePath();
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        return model.getGuiSettings();
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        model.setGuiSettings(guiSettings);
+    }
+}

--- a/src/main/java/seedu/address/model/EntityType.java
+++ b/src/main/java/seedu/address/model/EntityType.java
@@ -1,7 +1,0 @@
-package seedu.address.model;
-
-public enum EntityType {
-    STUDENT,
-    CLASS_GROUP,
-    MODULE
-}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -14,7 +14,7 @@ import seedu.address.model.tamodule.TaModule;
  * The API of the Model component.
  */
 public interface Model {
-    /** {@code Predicate} that always evaluate to true */
+    /** {@code Predicate} that always evaluate to true. */
     Predicate<Entity> PREDICATE_SHOW_ALL = unused -> true;
 
     /**
@@ -52,7 +52,7 @@ public interface Model {
      */
     void setTAssist(ReadOnlyTAssist tAssist);
 
-    /** Returns the TAssist */
+    /** Returns the TAssist. */
     ReadOnlyTAssist getTAssist();
 
     /**
@@ -79,13 +79,13 @@ public interface Model {
      */
     void setEntity(Entity target, Entity editedEntity);
 
-    /** Returns an unmodifiable view of the filtered student list */
+    /** Returns an unmodifiable view of the filtered student list. */
     ObservableList<Student> getFilteredStudentList();
 
-    /** Returns an unmodifiable view of the filtered module list */
+    /** Returns an unmodifiable view of the filtered module list. */
     ObservableList<TaModule> getFilteredModuleList();
 
-    /** Returns an unmodifiable view of the filtered class group list */
+    /** Returns an unmodifiable view of the filtered class group list. */
     ObservableList<ClassGroup> getFilteredClassGroupList();
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,0 +1,108 @@
+package seedu.address.model;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.classgroup.ClassGroup;
+import seedu.address.model.entity.Entity;
+import seedu.address.model.student.Student;
+import seedu.address.model.tamodule.TaModule;
+
+/**
+ * The API of the Model component.
+ */
+public interface Model {
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Entity> PREDICATE_SHOW_ALL = unused -> true;
+
+    /**
+     * Replaces user prefs data with the data in {@code userPrefs}.
+     */
+    void setUserPrefs(ReadOnlyUserPrefs userPrefs);
+
+    /**
+     * Returns the user prefs.
+     */
+    ReadOnlyUserPrefs getUserPrefs();
+
+    /**
+     * Returns the user prefs' GUI settings.
+     */
+    GuiSettings getGuiSettings();
+
+    /**
+     * Sets the user prefs' GUI settings.
+     */
+    void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the user prefs' TAssist file path.
+     */
+    Path getTAssistFilePath();
+
+    /**
+     * Sets the user prefs' TAssist file path.
+     */
+    void setTAssistFilePath(Path tAssistFilePath);
+
+    /**
+     * Replaces TAssist data with the data in {@code TAssist}.
+     */
+    void setTAssist(ReadOnlyTAssist tAssist);
+
+    /** Returns the TAssist */
+    ReadOnlyTAssist getTAssist();
+
+    /**
+     * Returns true if an entity with the same identity as {@code entity} exists in the TAssist.
+     */
+    boolean hasEntity(Entity entity);
+
+    /**
+     * Deletes the given entity.
+     * The entity must exist in the TAssist.
+     */
+    void deleteEntity(Entity target);
+
+    /**
+     * Adds the given entity.
+     * {@code entity} must not already exist in the TAssist.
+     */
+    void addEntity(Entity entity);
+
+    /**
+     * Replaces the given entity {@code target} with {@code editedEntity}.
+     * {@code target} must exist in the TAssist.
+     * The entity identity of {@code editedEntity} must not be the same as another existing entity in the TAssist.
+     */
+    void setEntity(Entity target, Entity editedEntity);
+
+    /** Returns an unmodifiable view of the filtered student list */
+    ObservableList<Student> getFilteredStudentList();
+
+    /** Returns an unmodifiable view of the filtered module list */
+    ObservableList<TaModule> getFilteredModuleList();
+
+    /** Returns an unmodifiable view of the filtered class group list */
+    ObservableList<ClassGroup> getFilteredClassGroupList();
+
+    /**
+     * Updates the filter of the filtered student list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredStudentList(Predicate<? super Student> predicate);
+
+    /**
+     * Updates the filter of the filtered module list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredModuleList(Predicate<? super TaModule> predicate);
+
+    /**
+     * Updates the filter of the filtered class group list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredClassGroupList(Predicate<? super ClassGroup> predicate);
+}

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -1,0 +1,243 @@
+package seedu.address.model;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.logging.Logger;
+
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.classgroup.ClassGroup;
+import seedu.address.model.entity.Entity;
+import seedu.address.model.entity.EntityConverter;
+import seedu.address.model.entity.exceptions.DifferentEntityException;
+import seedu.address.model.entity.exceptions.UnknownEntityException;
+import seedu.address.model.student.Student;
+import seedu.address.model.tamodule.TaModule;
+
+/**
+ * Represents the in-memory model of the address book data.
+ */
+public class ModelManager implements Model {
+    private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
+
+    private final TAssist tAssist;
+    private final UserPrefs userPrefs;
+    private final FilteredList<Student> filteredStudents;
+    private final FilteredList<TaModule> filteredModules;
+    private final FilteredList<ClassGroup> filteredClassGroups;
+
+    /**
+     * Initializes a ModelManager with the given tAssist and userPrefs.
+     */
+    public ModelManager(ReadOnlyTAssist tAssist, ReadOnlyUserPrefs userPrefs) {
+        requireAllNonNull(tAssist, userPrefs);
+
+        logger.fine("Initializing with TAssist: " + tAssist + " and user prefs " + userPrefs);
+
+        this.tAssist = new TAssist(tAssist);
+        this.userPrefs = new UserPrefs(userPrefs);
+        filteredStudents = new FilteredList<>(this.tAssist.getStudentList());
+        filteredModules = new FilteredList<>(this.tAssist.getModuleList());
+        filteredClassGroups = new FilteredList<>(this.tAssist.getClassGroupList());
+    }
+
+    public ModelManager() {
+        this(new TAssist(), new UserPrefs());
+    }
+
+    //=========== UserPrefs ==================================================================================
+
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        requireNonNull(userPrefs);
+        this.userPrefs.resetData(userPrefs);
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        return userPrefs;
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        return userPrefs.getGuiSettings();
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        requireNonNull(guiSettings);
+        userPrefs.setGuiSettings(guiSettings);
+    }
+
+
+    /** To update method and change user pref method into getTAssistFilePath */
+    @Override
+    public Path getTAssistFilePath() {
+        return userPrefs.getAddressBookFilePath();
+    }
+
+    /** To update method and change user pref method into setTAssistFilePath */
+    @Override
+    public void setTAssistFilePath(Path tAssistFilePath) {
+        requireNonNull(tAssistFilePath);
+        userPrefs.setAddressBookFilePath(tAssistFilePath);
+    }
+
+    //=========== TAssist ================================================================================
+
+    @Override
+    public void setTAssist(ReadOnlyTAssist tAssist) {
+        this.tAssist.resetData(tAssist);
+    }
+
+    @Override
+    public ReadOnlyTAssist getTAssist() {
+        return tAssist;
+    }
+
+    @Override
+    public boolean hasEntity(Entity entity) {
+        requireNonNull(entity);
+        switch (entity.getEntityType()) {
+        case STUDENT:
+            return tAssist.hasStudent(EntityConverter.entityToStudent(entity));
+        case TA_MODULE:
+            return tAssist.hasModule(EntityConverter.entityToTaModule(entity));
+        case CLASS_GROUP:
+            return tAssist.hasClassGroup(EntityConverter.entityToClassGroup(entity));
+        default:
+            throw new UnknownEntityException();
+        }
+    }
+
+    @Override
+    public void deleteEntity(Entity target) {
+        requireNonNull(target);
+        switch (target.getEntityType()) {
+        case STUDENT:
+            tAssist.removeStudent(EntityConverter.entityToStudent(target));
+            break;
+        case TA_MODULE:
+            tAssist.removeModule(EntityConverter.entityToTaModule(target));
+            break;
+        case CLASS_GROUP:
+            tAssist.removeClassGroup(EntityConverter.entityToClassGroup(target));
+            break;
+        default:
+            throw new UnknownEntityException();
+        }
+    }
+
+    @Override
+    public void addEntity(Entity entity) {
+        requireNonNull(entity);
+        switch (entity.getEntityType()) {
+        case STUDENT:
+            tAssist.addStudent(EntityConverter.entityToStudent(entity));
+            updateFilteredStudentList(PREDICATE_SHOW_ALL);
+            break;
+        case TA_MODULE:
+            tAssist.addModule(EntityConverter.entityToTaModule(entity));
+            updateFilteredModuleList(PREDICATE_SHOW_ALL);
+            break;
+        case CLASS_GROUP:
+            tAssist.addClassGroup(EntityConverter.entityToClassGroup(entity));
+            updateFilteredClassGroupList(PREDICATE_SHOW_ALL);
+            break;
+        default:
+            throw new UnknownEntityException();
+        }
+    }
+
+    @Override
+    public void setEntity(Entity target, Entity editedEntity) {
+        requireAllNonNull(target, editedEntity);
+        switch (target.getEntityType()) {
+        case STUDENT:
+            Student targetStudent = EntityConverter.entityToStudent(target);
+            Student editedStudent = EntityConverter.entityToStudent(editedEntity);
+            tAssist.setStudent(targetStudent, editedStudent);
+            break;
+        case TA_MODULE:
+            TaModule targetModule = EntityConverter.entityToTaModule(target);
+            TaModule editedModule = EntityConverter.entityToTaModule(editedEntity);
+            tAssist.setModule(targetModule, editedModule);
+            break;
+        case CLASS_GROUP:
+            ClassGroup targetClassGroup = EntityConverter.entityToClassGroup(target);
+            ClassGroup editedClassGroup = EntityConverter.entityToClassGroup(editedEntity);
+            tAssist.setClassGroup(targetClassGroup, editedClassGroup);
+            break;
+        default:
+            throw new DifferentEntityException(target.getEntityType(), editedEntity.getEntityType());
+        }
+    }
+
+    //=========== Filtered List Accessors =============================================================
+
+    /**
+     * Returns an unmodifiable view of the list of the various entities backed by the internal list of
+     * {@code versionedTAssist}
+     */
+
+
+    @Override
+    public ObservableList<Student> getFilteredStudentList() {
+        return filteredStudents;
+    }
+
+    @Override
+    public ObservableList<TaModule> getFilteredModuleList() {
+        return filteredModules;
+    }
+
+    @Override
+    public ObservableList<ClassGroup> getFilteredClassGroupList() {
+        return filteredClassGroups;
+    }
+
+    @Override
+    public void updateFilteredStudentList(Predicate<? super Student> predicate) {
+        requireNonNull(predicate);
+        filteredStudents.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredModuleList(Predicate<? super TaModule> predicate) {
+        requireNonNull(predicate);
+        filteredModules.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredClassGroupList(Predicate<? super ClassGroup> predicate) {
+        requireNonNull(predicate);
+        filteredClassGroups.setPredicate(predicate);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        // short circuit if same object
+        if (obj == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(obj instanceof ModelManager)) {
+            return false;
+        }
+
+        // state check
+        ModelManager other = (ModelManager) obj;
+        return tAssist.equals(other.tAssist)
+                && userPrefs.equals(other.userPrefs)
+                && filteredStudents.equals(other.filteredStudents)
+                && filteredModules.equals(other.filteredModules)
+                && filteredClassGroups.equals(other.filteredClassGroups);
+    }
+
+}

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -75,13 +75,13 @@ public class ModelManager implements Model {
     }
 
 
-    /** To update method and change user pref method into getTAssistFilePath */
+    /** TODO: update method and change user pref method into getTAssistFilePath. */
     @Override
     public Path getTAssistFilePath() {
         return userPrefs.getAddressBookFilePath();
     }
 
-    /** To update method and change user pref method into setTAssistFilePath */
+    /** TODO: update method and change user pref method into setTAssistFilePath. */
     @Override
     public void setTAssistFilePath(Path tAssistFilePath) {
         requireNonNull(tAssistFilePath);
@@ -182,7 +182,7 @@ public class ModelManager implements Model {
 
     /**
      * Returns an unmodifiable view of the list of the various entities backed by the internal list of
-     * {@code versionedTAssist}
+     * {@code versionedTAssist}.
      */
 
 

--- a/src/main/java/seedu/address/model/ReadOnlyTAssist.java
+++ b/src/main/java/seedu/address/model/ReadOnlyTAssist.java
@@ -1,0 +1,23 @@
+package seedu.address.model;
+
+import javafx.collections.ObservableList;
+import seedu.address.model.classgroup.ClassGroup;
+import seedu.address.model.student.Student;
+import seedu.address.model.tamodule.TaModule;
+
+/**
+ * Unmodifiable view of an address book
+ */
+public interface ReadOnlyTAssist {
+
+    /**
+     * Returns an unmodifiable view of the persons list.
+     * This list will not contain any duplicate persons.
+     */
+    ObservableList<Student> getStudentList();
+
+    ObservableList<TaModule> getModuleList();
+
+    ObservableList<ClassGroup> getClassGroupList();
+
+}

--- a/src/main/java/seedu/address/model/ReadOnlyTAssist.java
+++ b/src/main/java/seedu/address/model/ReadOnlyTAssist.java
@@ -6,7 +6,7 @@ import seedu.address.model.student.Student;
 import seedu.address.model.tamodule.TaModule;
 
 /**
- * Unmodifiable view of an address book
+ * Unmodifiable view of an address book.
  */
 public interface ReadOnlyTAssist {
 

--- a/src/main/java/seedu/address/model/TAssist.java
+++ b/src/main/java/seedu/address/model/TAssist.java
@@ -1,0 +1,238 @@
+package seedu.address.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Objects;
+
+import javafx.collections.ObservableList;
+import seedu.address.model.classgroup.ClassGroup;
+import seedu.address.model.classgroup.UniqueClassGroupList;
+import seedu.address.model.student.Student;
+import seedu.address.model.student.UniqueStudentList;
+import seedu.address.model.tamodule.TaModule;
+import seedu.address.model.tamodule.UniqueModuleList;
+
+/**
+ * Wraps all data at the TAssist level
+ * Duplicates are not allowed (by .isSameX comparison, where X is the corresponding entity)
+ */
+public class TAssist implements ReadOnlyTAssist {
+
+    private final UniqueStudentList students;
+    private final UniqueModuleList modules;
+    private final UniqueClassGroupList classGroups;
+
+    /*
+     * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
+     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
+     *
+     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
+     *   among constructors.
+     */
+    {
+        students = new UniqueStudentList();
+        modules = new UniqueModuleList();
+        classGroups = new UniqueClassGroupList();
+    }
+
+    public TAssist() {
+    }
+
+    /**
+     * Creates an TAssist using the lists in the {@code toBeCopied}
+     */
+    public TAssist(ReadOnlyTAssist toBeCopied) {
+        this();
+        resetData(toBeCopied);
+    }
+
+    //// list overwrite operations
+
+    /**
+     * Replaces the contents of the student list with {@code students}.
+     * {@code students} must not contain duplicate students.
+     */
+    public void setStudents(List<Student> students) {
+        this.students.setStudents(students);
+    }
+
+    /**
+     * Replaces the contents of the module list with {@code modules}.
+     * {@code modules} must not contain duplicate modules.
+     */
+    public void setModules(List<TaModule> taModules) {
+        this.modules.setModules(taModules);
+    }
+
+    /**
+     * Replaces the contents of the class group list with {@code classGroups}.
+     * {@code classGroups} must not contain duplicate class groups.
+     */
+    public void setClassGroups(List<ClassGroup> classGroups) {
+        this.classGroups.setClassGroups(classGroups);
+    }
+
+    /**
+     * Resets the existing data of this {@code TAssist} with {@code newData}.
+     */
+    public void resetData(ReadOnlyTAssist newData) {
+        requireNonNull(newData);
+
+        setStudents(newData.getStudentList());
+        setModules(newData.getModuleList());
+        setClassGroups(newData.getClassGroupList());
+    }
+
+    //// student-level operations
+
+    /**
+     * Returns true if a student with the same identity as {@code student} exists in the TAssist.
+     */
+    public boolean hasStudent(Student student) {
+        requireNonNull(student);
+        return students.contains(student);
+    }
+
+    /**
+     * Adds a student to the TAssist.
+     * The student must not already exist in the TAssist.
+     */
+    public void addStudent(Student student) {
+        students.add(student);
+    }
+
+    /**
+     * Replaces the given student {@code target} in the list with {@code editedStudent}.
+     * {@code target} must exist in the TAssist.
+     * The student identity of {@code editedStudent} must not be the same as another existing student in the TAssist.
+     */
+    public void setStudent(Student target, Student editedStudent) {
+        requireNonNull(editedStudent);
+
+        students.setStudent(target, editedStudent);
+    }
+
+    /**
+     * Removes {@code key} from this {@code TAssist}.
+     * {@code key} must exist in the TAssist.
+     */
+    public void removeStudent(Student key) {
+        students.remove(key);
+    }
+
+    //// module-level operations
+
+    /**
+     * Returns true if a module with the same identity as {@code module} exists in the TAssist.
+     */
+    public boolean hasModule(TaModule module) {
+        requireNonNull(module);
+        return modules.contains(module);
+    }
+
+    /**
+     * Adds a module to the TAssist.
+     * The module must not already exist in the TAssist.
+     */
+    public void addModule(TaModule module) {
+        modules.add(module);
+    }
+
+    /**
+     * Replaces the given module {@code target} in the list with {@code editedTaModule}.
+     * {@code target} must exist in the TAssist.
+     * The module identity of {@code editedTaModule} must not be the same as another existing module in the TAssist.
+     */
+    public void setModule(TaModule target, TaModule editedTaModule) {
+        requireNonNull(editedTaModule);
+
+        modules.setModule(target, editedTaModule);
+    }
+
+    /**
+     * Removes {@code key} from this {@code TAssist}.
+     * {@code key} must exist in the TAssist.
+     */
+    public void removeModule(TaModule key) {
+        modules.remove(key);
+    }
+
+    //// classGroup-level operations
+
+    /**
+     * Returns true if a classGroup with the same identity as {@code classGroup} exists in the TAssist.
+     */
+    public boolean hasClassGroup(ClassGroup classGroup) {
+        requireNonNull(classGroup);
+        return classGroups.contains(classGroup);
+    }
+
+    /**
+     * Adds a classGroup to the TAssist.
+     * The classGroup must not already exist in the TAssist.
+     */
+    public void addClassGroup(ClassGroup classGroup) {
+        classGroups.add(classGroup);
+    }
+
+    /**
+     * Replaces the given classGroup {@code target} in the list with {@code editedClassGroup}.
+     * {@code target} must exist in the TAssist.
+     * The classGroup identity of {@code editedClassGroup} must not be the same as another
+     * existing classGroup in the TAssist.
+     */
+    public void setClassGroup(ClassGroup target, ClassGroup editedClassGroup) {
+        requireNonNull(editedClassGroup);
+
+        classGroups.setClassGroup(target, editedClassGroup);
+    }
+
+    /**
+     * Removes {@code key} from this {@code TAssist}.
+     * {@code key} must exist in the TAssist.
+     */
+    public void removeClassGroup(ClassGroup key) {
+        classGroups.remove(key);
+    }
+
+    //// util methods
+
+    @Override
+    public String toString() {
+        return students.asUnmodifiableObservableList().size() + " students"
+                + modules.asUnmodifiableObservableList().size() + " modules"
+                + classGroups.asUnmodifiableObservableList().size() + " class groups";
+        // TODO: refine later
+    }
+
+    @Override
+    public ObservableList<Student> getStudentList() {
+        return students.asUnmodifiableObservableList();
+    }
+
+
+    @Override
+    public ObservableList<TaModule> getModuleList() {
+        return modules.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<ClassGroup> getClassGroupList() {
+        return classGroups.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TAssist // instanceof handles nulls
+                && students.equals(((TAssist) other).students)
+                && modules.equals(((TAssist) other).modules)
+                && classGroups.equals(((TAssist) other).classGroups));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(students, modules, classGroups);
+    }
+}

--- a/src/main/java/seedu/address/model/TAssist.java
+++ b/src/main/java/seedu/address/model/TAssist.java
@@ -14,8 +14,8 @@ import seedu.address.model.tamodule.TaModule;
 import seedu.address.model.tamodule.UniqueModuleList;
 
 /**
- * Wraps all data at the TAssist level
- * Duplicates are not allowed (by .isSameX comparison, where X is the corresponding entity)
+ * Wraps all data at the TAssist level.
+ * Duplicates are not allowed (by .isSameX comparison, where X is the corresponding entity).
  */
 public class TAssist implements ReadOnlyTAssist {
 
@@ -40,7 +40,7 @@ public class TAssist implements ReadOnlyTAssist {
     }
 
     /**
-     * Creates an TAssist using the lists in the {@code toBeCopied}
+     * Creates a TAssist using the lists in the {@code toBeCopied}.
      */
     public TAssist(ReadOnlyTAssist toBeCopied) {
         this();

--- a/src/main/java/seedu/address/model/classgroup/ClassGroup.java
+++ b/src/main/java/seedu/address/model/classgroup/ClassGroup.java
@@ -2,13 +2,15 @@ package seedu.address.model.classgroup;
 
 import java.util.Objects;
 
+import seedu.address.model.entity.Entity;
+import seedu.address.model.entity.EntityType;
 import seedu.address.model.tamodule.ModuleCode;
 
 /**
  * Represents a ClassGroup in the TAssist.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class ClassGroup {
+public class ClassGroup implements Entity {
     // Identity fields
     private final ClassGroupId classGroupId;
     private final ClassGroupType classGroupType;
@@ -38,6 +40,11 @@ public class ClassGroup {
 
     public ModuleCode getModuleCode() {
         return moduleCode;
+    }
+
+    @Override
+    public EntityType getEntityType() {
+        return EntityType.CLASS_GROUP;
     }
 
     /**

--- a/src/main/java/seedu/address/model/entity/Entity.java
+++ b/src/main/java/seedu/address/model/entity/Entity.java
@@ -1,0 +1,8 @@
+package seedu.address.model.entity;
+
+/**
+ * The Entity interface is used to group all the models together.
+ */
+public interface Entity {
+    EntityType getEntityType();
+}

--- a/src/main/java/seedu/address/model/entity/EntityConverter.java
+++ b/src/main/java/seedu/address/model/entity/EntityConverter.java
@@ -1,0 +1,51 @@
+package seedu.address.model.entity;
+
+import seedu.address.model.classgroup.ClassGroup;
+import seedu.address.model.entity.exceptions.InvalidEntityConversionException;
+import seedu.address.model.student.Student;
+import seedu.address.model.tamodule.TaModule;
+
+/**
+ * The API of the Model component.
+ */
+public class EntityConverter {
+
+    /**
+     * Converts the entity to a {@code Student} class.
+     *
+     * @param entity the entity to convert
+     * @return The {@code Student} class that the entity represent.
+     */
+    public static Student entityToStudent(Entity entity) {
+        if (entity.getEntityType() != EntityType.STUDENT) {
+            throw new InvalidEntityConversionException(EntityType.STUDENT);
+        }
+        return (Student) entity;
+    }
+
+    /**
+     * Converts the entity to a {@code TaModule} class.
+     *
+     * @param entity the entity to convert
+     * @return The {@code TaModule} class that the entity represent.
+     */
+    public static TaModule entityToTaModule(Entity entity) {
+        if (entity.getEntityType() != EntityType.TA_MODULE) {
+            throw new InvalidEntityConversionException(EntityType.TA_MODULE);
+        }
+        return (TaModule) entity;
+    }
+
+    /**
+     * Converts the entity to a {@code ClassGroup} class.
+     *
+     * @param entity the entity to convert
+     * @return The {@code ClassGroup} class that the entity represent.
+     */
+    public static ClassGroup entityToClassGroup(Entity entity) {
+        if (entity.getEntityType() != EntityType.CLASS_GROUP) {
+            throw new InvalidEntityConversionException(EntityType.CLASS_GROUP);
+        }
+        return (ClassGroup) entity;
+    }
+}

--- a/src/main/java/seedu/address/model/entity/EntityConverter.java
+++ b/src/main/java/seedu/address/model/entity/EntityConverter.java
@@ -13,7 +13,7 @@ public class EntityConverter {
     /**
      * Converts the entity to a {@code Student} class.
      *
-     * @param entity the entity to convert
+     * @param entity The entity to convert.
      * @return The {@code Student} class that the entity represent.
      */
     public static Student entityToStudent(Entity entity) {
@@ -26,7 +26,7 @@ public class EntityConverter {
     /**
      * Converts the entity to a {@code TaModule} class.
      *
-     * @param entity the entity to convert
+     * @param entity The entity to convert.
      * @return The {@code TaModule} class that the entity represent.
      */
     public static TaModule entityToTaModule(Entity entity) {
@@ -39,7 +39,7 @@ public class EntityConverter {
     /**
      * Converts the entity to a {@code ClassGroup} class.
      *
-     * @param entity the entity to convert
+     * @param entity The entity to convert.
      * @return The {@code ClassGroup} class that the entity represent.
      */
     public static ClassGroup entityToClassGroup(Entity entity) {

--- a/src/main/java/seedu/address/model/entity/EntityType.java
+++ b/src/main/java/seedu/address/model/entity/EntityType.java
@@ -1,0 +1,21 @@
+package seedu.address.model.entity;
+
+/**
+ * Enum class to indicate the different entities in TAssist.
+ */
+public enum EntityType {
+    STUDENT("Student"),
+    CLASS_GROUP("ClassGroup"),
+    TA_MODULE("TaModule");
+
+    private final String entityClass;
+
+    EntityType(String entityClass) {
+        this.entityClass = entityClass;
+    }
+
+    @Override
+    public String toString() {
+        return entityClass;
+    }
+}

--- a/src/main/java/seedu/address/model/entity/exceptions/DifferentEntityException.java
+++ b/src/main/java/seedu/address/model/entity/exceptions/DifferentEntityException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.entity.exceptions;
+
+import seedu.address.model.entity.EntityType;
+
+/**
+ * Signals that the operation will result in setting one entity type as another entity type.
+ */
+public class DifferentEntityException extends RuntimeException {
+    public DifferentEntityException(EntityType type, EntityType otherType) {
+        super(String.format("Attempting to set %s as %s", type.toString(), otherType.toString()));
+    }
+}

--- a/src/main/java/seedu/address/model/entity/exceptions/InvalidEntityConversionException.java
+++ b/src/main/java/seedu/address/model/entity/exceptions/InvalidEntityConversionException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.entity.exceptions;
+
+import seedu.address.model.entity.EntityType;
+
+/**
+ * Signals that the operation will result in invalid entity conversion.
+ */
+public class InvalidEntityConversionException extends RuntimeException {
+    public InvalidEntityConversionException(EntityType expectedType) {
+        super("Invalid conversion of Entity to " + expectedType.toString());
+    }
+}

--- a/src/main/java/seedu/address/model/entity/exceptions/UnknownEntityException.java
+++ b/src/main/java/seedu/address/model/entity/exceptions/UnknownEntityException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.entity.exceptions;
+
+/**
+ * Signals that the entity is unknown (not listed inside {@code EntityType} enum)
+ */
+public class UnknownEntityException extends RuntimeException {
+    public UnknownEntityException() {
+        super("The entity type does not exist.");
+    }
+}

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -4,11 +4,14 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
+import seedu.address.model.entity.Entity;
+import seedu.address.model.entity.EntityType;
+
 /**
  * Represents a Student in the TAssist.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Student {
+public class Student implements Entity {
 
     // Identity fields
     private final StudentId studentId;
@@ -54,6 +57,11 @@ public class Student {
 
         return otherStudent != null
                 && otherStudent.getName().equals(getName());
+    }
+
+    @Override
+    public EntityType getEntityType() {
+        return EntityType.STUDENT;
     }
 
     /**

--- a/src/main/java/seedu/address/model/tamodule/TaModule.java
+++ b/src/main/java/seedu/address/model/tamodule/TaModule.java
@@ -4,12 +4,15 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
+import seedu.address.model.entity.Entity;
+import seedu.address.model.entity.EntityType;
+
 /**
  * Represents a Module in the TAssist.
  * It is named TaModule as it conflicts with the class java.lang.Module.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class TaModule {
+public class TaModule implements Entity {
 
     // Identity fields
     private final ModuleName moduleName;
@@ -43,6 +46,11 @@ public class TaModule {
 
         return otherTaModule != null
                 && otherTaModule.getModuleCode().equals(getModuleCode());
+    }
+
+    @Override
+    public EntityType getEntityType() {
+        return EntityType.TA_MODULE;
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -13,6 +13,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.AB3Logic;
+import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -28,7 +29,7 @@ public class MainWindow extends UiPart<Stage> {
     private final Logger logger = LogsCenter.getLogger(getClass());
 
     private Stage primaryStage;
-    private AB3Logic logic;
+    private Logic logic;
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
@@ -53,7 +54,7 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
      */
-    public MainWindow(Stage primaryStage, AB3Logic logic) {
+    public MainWindow(Stage primaryStage, Logic logic) {
         super(FXML, primaryStage);
 
         // Set dependencies
@@ -116,7 +117,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
+        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getTAssistFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand);

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -10,7 +10,7 @@ import javafx.stage.Stage;
 import seedu.address.MainApp;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.StringUtil;
-import seedu.address.logic.AB3Logic;
+import seedu.address.logic.Logic;
 
 /**
  * The manager of the UI component.
@@ -22,13 +22,13 @@ public class UiManager implements Ui {
     private static final Logger logger = LogsCenter.getLogger(UiManager.class);
     private static final String ICON_APPLICATION = "/images/address_book_32.png";
 
-    private AB3Logic logic;
+    private Logic logic;
     private MainWindow mainWindow;
 
     /**
      * Creates a {@code UiManager} with the given {@code Logic}.
      */
-    public UiManager(AB3Logic logic) {
+    public UiManager(Logic logic) {
         this.logic = logic;
     }
 


### PR DESCRIPTION
Create `Entity` class to group `Student`, `TaModule` and `ClassGroup`, closes #60 

Grouping the classes will allow better abstraction in logic, e.g. to change add entity in the model one can call model.addEntity(entity).

Create `TAssist` as an abstraction for all 3 lists used in `Model`

Update `MainApp` to use modified `Logic` and `Model`

`Logic` still contain traces of AB3 (getFilteredPersonList method), to be removed once Ui does not need this method.

closes #59